### PR TITLE
release: cosign v3 bundle signing for checksums

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,17 +31,16 @@ changelog:
   sort: desc
   use: git
 
-# Keyless signing of the checksums file with cosign (Sigstore); verifiable via
-# cosign verify-blob and detected by OpenSSF Scorecard's Signed-Releases check.
+# Keyless signing of the checksums file with cosign v3 (Sigstore bundle);
+# verify with: cosign verify-blob --bundle <file>.sigstore <file>
+# The .sigstore asset is detected by OpenSSF Scorecard's Signed-Releases check.
 signs:
   - cmd: cosign
-    signature: '${artifact}.sig'
-    certificate: '${artifact}.pem'
+    signature: '${artifact}.sigstore'
     args:
       - sign-blob
       - '--yes'
-      - '--output-signature=${signature}'
-      - '--output-certificate=${certificate}'
+      - '--bundle=${signature}'
       - '${artifact}'
     artifacts: checksum
     output: true


### PR DESCRIPTION
cosign v3 (installed by cosign-installer v4) removed --output-signature/--output-certificate from sign-blob; the v1.1.0 release run failed on signing. Switch to the v3 bundle flow: sign-blob --bundle producing checksums.txt.sigstore (matches Scorecard's Signed-Releases patterns; verify with cosign verify-blob --bundle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)