### PR TITLE
ci: coverage badge job gated on build success

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,11 +50,12 @@ jobs:
         run: go build ./...
 
       - name: Test
-        run: go test ./... -race -count=1 -coverprofile=coverage.out -covermode=atomic
+        run: go test ./... -race -count=1
 
   coverage-badge:
     name: coverage badge
     runs-on: ubuntu-latest
+    needs: build
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
       # Pushes the generated badge SVG to the 'badges' branch


### PR DESCRIPTION
Copilot follow-ups from #22: badge job now needs build (no badge from a broken main), PR test runs drop the unused coverage profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)